### PR TITLE
Fix: ensure user is logged in after successful registration #13

### DIFF
--- a/App/Controllers/User.php
+++ b/App/Controllers/User.php
@@ -42,17 +42,23 @@ class User extends \Core\Controller
      */
     public function registerAction()
     {
-        if(isset($_POST['submit'])){
+        if (isset($_POST['submit'])) {
             $f = $_POST;
 
-            if($f['password'] !== $f['password-check']){
+            if ($f['password'] !== $f['password-check']) {
                 // TODO: Gestion d'erreur côté utilisateur
             }
 
-            // validation
+            // Validation (optionnelle)
 
             $this->register($f);
-            // TODO: Rappeler la fonction de login pour connecter l'utilisateur
+
+            // ✅ Connexion automatique
+            $this->login($f);
+
+            // ✅ Redirection vers le compte
+            header('Location: /account');
+            return;
         }
 
         View::renderTemplate('User/register.html');


### PR DESCRIPTION
## Description

This PR fixes the issue where a user is not automatically logged in after successfully registering an account.

## Related Issue

Closes #13 

## Changes

- Calls the `login()` method right after successful user registration
- Ensures the user session is properly initialized
- Redirects the user to `/account` immediately after registering

## Steps to Test

1. Go to the registration page
2. Fill out the form with valid credentials
3. Submit the form
4. ✅ The user should now be logged in automatically and redirected to `/account`

## Notes

- ⚠️ Password confirmation validation (`password` === `password-check`) is still marked as a TODO and tracked in issue #19 
- Flash messages and error handling also remain to be implemented

